### PR TITLE
Print status messages to stderr

### DIFF
--- a/energytrace.c
+++ b/energytrace.c
@@ -32,11 +32,11 @@ void push_cb(void* pContext, const uint8_t* pBuffer, uint32_t nBufferSize) {
 }
 
 void error_cb(void* pContext, const char* pszErrorText) {
-	printf("error %s\n", pszErrorText);
+	fprintf(stderr, "error %s\n", pszErrorText);
 }
 
 void usage(char *a0) {
-	printf("usage: %s <measurement duration in seconds>\n", a0);
+	fprintf(stderr, "usage: %s <measurement duration in seconds>\n", a0);
 }
 
 int main(int argc, char *argv[]) {
@@ -58,47 +58,47 @@ int main(int argc, char *argv[]) {
 	union DEVICE_T device;
 	portNumber = "TIUSB";
 	
-	printf("#Initializing the interface: ");
+	fprintf(stderr, "Initializing the interface: ");
 	status = MSP430_Initialize(portNumber, &version);
-	printf("#MSP430_Initialize(portNumber=%s, version=%d) returns %d\n", portNumber, version, status);
+	fprintf(stderr, "MSP430_Initialize(portNumber=%s, version=%d) returns %d\n", portNumber, version, status);
 	if(status != STATUS_OK) {
 		return 1;
 	}
 
 	//status = MSP430_Configure(ET_CURRENTDRIVE_FINE, 1);
-	//printf("#MSP430_Configure(ET_CURRENTDRIVE_FINE, 1) =%d\n", status);
+	//fprintf(stderr, "MSP430_Configure(ET_CURRENTDRIVE_FINE, 1) =%d\n", status);
 
 	// 2. Set the device Vcc.
-	printf("#Setting the device Vcc: ");
+	fprintf(stderr, "Setting the device Vcc: ");
 	status = MSP430_VCC(vcc);
-	printf("#MSP430_VCC(%d) returns %d\n", vcc, status);
+	fprintf(stderr, "MSP430_VCC(%d) returns %d\n", vcc, status);
 
 
 	// 3. Open the device.
 	MSP430_LoadDeviceDb(NULL); //Required in more recent versions of tilib.
-	printf("#Opening the device: ");
+	fprintf(stderr, "Opening the device: ");
 	status = MSP430_OpenDevice("DEVICE_UNKNOWN", "", 0, 0, DEVICE_UNKNOWN);
-	printf("#MSP430_OpenDevice() returns %d\n", status);
+	fprintf(stderr, "MSP430_OpenDevice() returns %d\n", status);
 	if(status != STATUS_OK) {
 		return 1;
 	}
 
 	// 4. Get device information
 	status = MSP430_GetFoundDevice((char*)&device, sizeof(device.buffer));
-	printf("#MSP430_GetFoundDevice() returns %d\n", status);
-	printf("# device.id: %d\n", device.id);
-	printf("# device.string: %s\n", device.string);
-	printf("# device.mainStart: 0x%04x\n", device.mainStart);
-	printf("# device.infoStart: 0x%04x\n", device.infoStart);
-	printf("# device.ramEnd: 0x%04x\n", device.ramEnd);
-	printf("# device.nBreakpoints: %d\n", device.nBreakpoints);
-	printf("# device.emulation: %d\n", device.emulation);
-	printf("# device.clockControl: %d\n", device.clockControl);
-	printf("# device.lcdStart: 0x%04x\n", device.lcdStart);
-	printf("# device.lcdEnd: 0x%04x\n", device.lcdEnd);
-	printf("# device.vccMinOp: %d\n", device.vccMinOp);
-	printf("# device.vccMaxOp: %d\n", device.vccMaxOp);
-	printf("# device.hasTestVpp: %d\n", device.hasTestVpp);
+	fprintf(stderr, "MSP430_GetFoundDevice() returns %d\n", status);
+	fprintf(stderr, " device.id: %d\n", device.id);
+	fprintf(stderr, " device.string: %s\n", device.string);
+	fprintf(stderr, " device.mainStart: 0x%04x\n", device.mainStart);
+	fprintf(stderr, " device.infoStart: 0x%04x\n", device.infoStart);
+	fprintf(stderr, " device.ramEnd: 0x%04x\n", device.ramEnd);
+	fprintf(stderr, " device.nBreakpoints: %d\n", device.nBreakpoints);
+	fprintf(stderr, " device.emulation: %d\n", device.emulation);
+	fprintf(stderr, " device.clockControl: %d\n", device.clockControl);
+	fprintf(stderr, " device.lcdStart: 0x%04x\n", device.lcdStart);
+	fprintf(stderr, " device.lcdEnd: 0x%04x\n", device.lcdEnd);
+	fprintf(stderr, " device.vccMinOp: %d\n", device.vccMinOp);
+	fprintf(stderr, " device.vccMaxOp: %d\n", device.vccMaxOp);
+	fprintf(stderr, " device.hasTestVpp: %d\n", device.hasTestVpp);
 	
 	
 	EnergyTraceSetup ets = {  ET_PROFILING_ANALOG,                // Gives callbacks of with eventID 8
@@ -114,19 +114,19 @@ int main(int argc, char *argv[]) {
 	};
 	MSP430_Run(FREE_RUN, 1);
 	status = MSP430_EnableEnergyTrace(&ets, &cbs, &ha);
-	printf("#MSP430_EnableEnergyTrace=%d\n", status);
+	fprintf(stderr, "MSP430_EnableEnergyTrace=%d\n", status);
 	
 	status = MSP430_ResetEnergyTrace(ha);
-	printf("#MSP430_ResetEnergyTrace=%d\n", status);
+	fprintf(stderr, "MSP430_ResetEnergyTrace=%d\n", status);
 	
 	sleep(duration);
 	
 	status = MSP430_DisableEnergyTrace(ha);
-	printf("#MSP430_DisableEnergyTrace=%d\n", status);
+	fprintf(stderr, "MSP430_DisableEnergyTrace=%d\n", status);
 	
-	printf("#Closing the interface: ");
+	fprintf(stderr, "Closing the interface: ");
 	status = MSP430_Close(0);
-	printf("#MSP430_Close(FALSE) returns %d\n", status);
+	fprintf(stderr, "MSP430_Close(FALSE) returns %d\n", status);
 
 	return 0;
 }


### PR DESCRIPTION
Printing status messages to the same stream as the data is rather inconvenient IMO. By printing them to stderr, status messages are still visible in the terminal even if the data is redirected to a file with `energytrace 60 > energytrace.txt`. The resulting file is cleaner and additionally status and error messages can be seen without opening and searching the potentially very large data file. I've also removed the leading `#` symbols since they aren't needed anymore in this case.