### PR TITLE
Port energytrace to Windows

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,117 @@
+name: Build Windows Release
+
+on:
+  push:
+    branches: [ main, master ]
+    tags: [ 'v*' ]
+  pull_request:
+    branches: [ main, master ]
+  workflow_dispatch:
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up MSVC developer environment
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
+      - name: Clone MSP Debug Stack for headers
+        run: git clone --depth 1 https://github.com/AJenbo/mspds.git mspds-src
+        shell: bash
+
+      - name: Locate MSP430 headers
+        id: headers
+        run: |
+          $headerDir = Get-ChildItem -Path mspds-src -Recurse -Filter "MSP430.h" -File | Select-Object -First 1 -ExpandProperty DirectoryName
+          if (-not $headerDir) {
+            Write-Error "MSP430.h not found in mspds source"
+            exit 1
+          }
+          Write-Output "MSP430 headers found at: $headerDir"
+          echo "MSP430_INCLUDE_DIR=$headerDir" >> $env:GITHUB_OUTPUT
+        shell: pwsh
+
+      - name: Generate import library from .def file
+        run: lib /def:MSP430.def /out:MSP430.lib /machine:x64
+        shell: cmd
+
+      - name: Build with CMake (MSVC)
+        run: |
+          cmake -B build -A x64 -DMSP430_INCLUDE_DIR="${{ steps.headers.outputs.MSP430_INCLUDE_DIR }}" -DMSP430_LIBRARY="${{ github.workspace }}\MSP430.lib"
+          cmake --build build --config Release
+        shell: cmd
+
+      - name: Prepare release artifacts
+        run: |
+          mkdir release
+          copy build\Release\energytrace.exe release\
+          copy README.md release\
+        shell: cmd
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: energytrace-windows-x64
+          path: release/
+
+      - name: Create GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            release/energytrace.exe
+          body: |
+            ## energytrace for Windows (x64)
+
+            ### Requirements
+            - **MSP430 Debug Stack (MSP430.DLL)** must be installed.
+              Download from [TI's MSP Debug Stack](https://www.ti.com/tool/MSPDS) or install as part of Code Composer Studio.
+            - Place `MSP430.DLL` in the same directory as `energytrace.exe`, or ensure it is on your system PATH.
+
+            ### Usage
+            ```
+            energytrace.exe <measurement duration in seconds>
+            ```
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Clone MSP Debug Stack for headers
+        run: git clone --depth 1 https://github.com/AJenbo/mspds.git mspds-src
+
+      - name: Locate MSP430 headers
+        id: headers
+        run: |
+          HEADER_DIR=$(find mspds-src -name "MSP430.h" -printf '%h\n' | head -1)
+          if [ -z "$HEADER_DIR" ]; then
+            echo "MSP430.h not found in mspds source"
+            exit 1
+          fi
+          echo "MSP430 headers found at: $HEADER_DIR"
+          echo "MSP430_INCLUDE_DIR=$HEADER_DIR" >> "$GITHUB_OUTPUT"
+
+      - name: Build with CMake
+        run: |
+          cmake -B build \
+            -DMSP430_INCLUDE_DIR="${{ steps.headers.outputs.MSP430_INCLUDE_DIR }}"
+          cmake --build build
+        # Note: This will fail at link time without libmsp430.so installed,
+        # but validates the source compiles correctly on Linux.
+        continue-on-error: true
+
+      - name: Build with Makefile (if libmsp430 is installed)
+        run: |
+          if [ -f /usr/include/libmsp430/MSP430.h ]; then
+            make
+          else
+            echo "libmsp430 not installed, skipping Makefile build"
+          fi
+        continue-on-error: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,10 @@
 comm.log
 energytrace
+energytrace.exe
 energytrace.log
+build/
+*.lib
+*.obj
+*.o
+mspds-src/
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,58 @@
+cmake_minimum_required(VERSION 3.10)
+project(energytrace C)
+
+set(CMAKE_C_STANDARD 11)
+
+add_executable(energytrace energytrace.c)
+
+# MSP430 Debug Stack include directory
+# Users can set -DMSP430_INCLUDE_DIR=<path> to override
+if(NOT MSP430_INCLUDE_DIR)
+    if(WIN32)
+        # Common TI installation paths on Windows
+        find_path(MSP430_INCLUDE_DIR MSP430.h
+            PATHS
+            "C:/ti/msp430/MSP Debug Stack/include"
+            "C:/ti/ccs/ccs_base/DebugServer/drivers"
+            "$ENV{TI_MSPDS_DIR}/include"
+        )
+    else()
+        find_path(MSP430_INCLUDE_DIR MSP430.h
+            PATHS
+            /usr/include/libmsp430
+            /usr/local/include/libmsp430
+        )
+    endif()
+endif()
+
+if(MSP430_INCLUDE_DIR)
+    message(STATUS "MSP430 headers found at: ${MSP430_INCLUDE_DIR}")
+    target_include_directories(energytrace PRIVATE ${MSP430_INCLUDE_DIR})
+else()
+    message(FATAL_ERROR "MSP430 headers not found. Set -DMSP430_INCLUDE_DIR=<path>")
+endif()
+
+# MSP430 library
+if(WIN32)
+    # On Windows, link against MSP430.dll via import library
+    # Users can set -DMSP430_LIBRARY=<path> to override
+    if(NOT MSP430_LIBRARY)
+        find_library(MSP430_LIBRARY NAMES MSP430 msp430
+            PATHS
+            "C:/ti/msp430/MSP Debug Stack/lib"
+            "C:/ti/ccs/ccs_base/DebugServer/drivers"
+            "$ENV{TI_MSPDS_DIR}/lib"
+            "${CMAKE_CURRENT_SOURCE_DIR}"
+        )
+    endif()
+    if(MSP430_LIBRARY)
+        target_link_libraries(energytrace ${MSP430_LIBRARY})
+    else()
+        message(FATAL_ERROR "MSP430 library not found. Set -DMSP430_LIBRARY=<path>")
+    endif()
+else()
+    target_link_libraries(energytrace msp430)
+endif()
+
+# Install target
+install(TARGETS energytrace DESTINATION bin)

--- a/MSP430.def
+++ b/MSP430.def
@@ -1,0 +1,13 @@
+LIBRARY MSP430.dll
+EXPORTS
+    MSP430_Initialize
+    MSP430_VCC
+    MSP430_LoadDeviceDb
+    MSP430_OpenDevice
+    MSP430_GetFoundDevice
+    MSP430_Run
+    MSP430_Close
+    MSP430_Configure
+    MSP430_EnableEnergyTrace
+    MSP430_ResetEnergyTrace
+    MSP430_DisableEnergyTrace

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,10 @@ SRC = $(TARGET).c
 CFLAGS = -I/usr/include/libmsp430 -lmsp430
 
 all: $(TARGET)
-$(TARGET): $(SRC) 
+$(TARGET): $(SRC)
 	gcc $(CFLAGS) -o $@ $<
 clean:
-	rm -f $(TARGET)
+	rm -f $(TARGET) $(TARGET).exe
 
 run: all
 	./energytrace 5
@@ -15,4 +15,9 @@ run: all
 install: all
 	install -t /usr/local/bin $(TARGET)
 
-
+# Cross-compile for Windows (requires mingw-w64 and MSP430 headers)
+# Usage: make windows MSP430_WIN_INCLUDE=/path/to/msp430/include
+MINGW_CC = x86_64-w64-mingw32-gcc
+MSP430_WIN_INCLUDE ?= /usr/include/libmsp430
+windows: $(SRC) MSP430.def
+	$(MINGW_CC) -I$(MSP430_WIN_INCLUDE) -o $(TARGET).exe $< MSP430.def

--- a/README.md
+++ b/README.md
@@ -28,19 +28,47 @@ filtering the energy measurements leads to more accurate readings than
 the current measurement itself.
 
 # Dependencies
-You'll need MSP430 debug stack (libmsp430.so) and the usual 
-things like make and gcc. Unfortunately, building the MSP430 debug 
-stack is a bit difficult at this time since it's missing some 
-`#include` and triggers a
+You'll need MSP430 debug stack and the usual things like make and gcc
+(or CMake). Unfortunately, building the MSP430 debug stack is a bit
+difficult at this time since it's missing some `#include` and triggers a
 [compiler bug](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=71092).
-Using Arch Linux? You're lucky, I've created a PKGBUILD and patches for 
+Using Arch Linux? You're lucky, I've created a PKGBUILD and patches for
 easy installation: [aur-mspds](https://github.com/carrotIndustries/aur-mspds)
 At the time of writing, the AUR package mspds is broken.
 
 # How do I build and run?
+
+## Linux
 ```
 $ make
 $ ./energytrace <measurement duration in seconds> > energytrace.log
+```
+
+## Windows
+
+### Pre-built binary
+Download `energytrace.exe` from the
+[Releases](https://github.com/bigjosh/energytrace-util/releases) page.
+
+You will need **MSP430.DLL** from TI's
+[MSP Debug Stack](https://www.ti.com/tool/MSPDS) (also included with
+Code Composer Studio). Place `MSP430.DLL` in the same directory as
+`energytrace.exe` or on your system PATH.
+
+```
+> energytrace.exe <measurement duration in seconds> > energytrace.log
+```
+
+### Building from source on Windows
+Using CMake with Visual Studio:
+```
+> cmake -B build -DMSP430_INCLUDE_DIR="C:\path\to\msp430\include" -DMSP430_LIBRARY="C:\path\to\MSP430.lib"
+> cmake --build build --config Release
+```
+
+Or with the Makefile using MinGW:
+```
+> make windows MSP430_WIN_INCLUDE=C:\path\to\msp430\include
 ```
 
 Use you favourite tool for visualizing and processing the recorded data.

--- a/energytrace.c
+++ b/energytrace.c
@@ -1,13 +1,30 @@
 #include <stdio.h>
-#include <unistd.h>
 #include <stdlib.h>
 #include <stdbool.h>
 #include <inttypes.h>
 #include <assert.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+
 #include <MSP430.h>
 #include <MSP430_EnergyTrace.h>
 #include <MSP430_Debug.h>
 
+#ifdef _MSC_VER
+#pragma pack(push, 1)
+typedef struct {
+	uint8_t id;
+	uint64_t timestamp:56;
+	uint32_t current;
+	uint16_t voltage;
+	uint32_t energy;
+} event_t;
+#pragma pack(pop)
+#else
 typedef struct __attribute__((packed))  {
 	uint8_t id;
 	uint64_t timestamp:56;
@@ -15,6 +32,7 @@ typedef struct __attribute__((packed))  {
 	uint16_t voltage;
 	uint32_t energy;
 } event_t;
+#endif
 
 void push_cb(void* pContext, const uint8_t* pBuffer, uint32_t nBufferSize) {
 	assert(sizeof(event_t)==18);
@@ -119,7 +137,11 @@ int main(int argc, char *argv[]) {
 	status = MSP430_ResetEnergyTrace(ha);
 	printf("#MSP430_ResetEnergyTrace=%d\n", status);
 	
+#ifdef _WIN32
+	Sleep(duration * 1000);
+#else
 	sleep(duration);
+#endif
 	
 	status = MSP430_DisableEnergyTrace(ha);
 	printf("#MSP430_DisableEnergyTrace=%d\n", status);


### PR DESCRIPTION
- Add #ifdef _WIN32 conditionals for sleep() -> Sleep() and unistd.h -> windows.h
- Add #pragma pack support for MSVC (alongside existing GCC __attribute__((packed)))
- Add CMakeLists.txt for cross-platform building with CMake
- Add MSP430.def for generating Windows import library from MSP430.DLL
- Add GitHub Actions workflow to build Windows x64 executable and create releases on tagged pushes
- Update Makefile with mingw-w64 cross-compilation target
- Update README with Windows build/usage instructions
- Update .gitignore for Windows build artifacts

https://claude.ai/code/session_01F6C7tJrJ5UrKopqi6nGWbC